### PR TITLE
Change `before_install` to `install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
 services:
   - docker
 
-before_install:
+install:
   - docker build -t stefaneng/partyq .
   - docker ps -a
   - docker run -d -p 127.0.0.1:80:3000 stefaneng/partyq /bin/sh -c 'npm start'


### PR DESCRIPTION
So we only npm install once instead of twice in travis-ci
