### PR TITLE
Link checker tests

### DIFF
--- a/common/utils/functions.js
+++ b/common/utils/functions.js
@@ -1,5 +1,5 @@
 const youtubeRegex =
-        /(?:https?:\/\/)?(?:youtu\.be\/|(?:www\.)?youtube\.com\/(?:watch(?:\.php)?\?.*v=)|v\/)([a-zA-Z0-9\-_])/;
+        /(?:https?:\/\/)?(?:youtu\.be\/|(?:www\.)?youtube\.com\/(?:watch(?:\.php)?\?.*v=)|v\/|embed\/)([a-zA-Z0-9\-_])/;
 
 export function isLinkValid(url) {
   if (youtubeRegex.test(url)) {

--- a/common/utils/functions.js
+++ b/common/utils/functions.js
@@ -1,5 +1,5 @@
 const youtubeRegex =
-  /(?:https?:\/\/)?(?:youtu\.be\/|(?:www\.)?youtube\.com\/watch(?:\.php)?\?.*v=)([a-zA-Z0-9\-_])/;
+        /(?:https?:\/\/)?(?:youtu\.be\/|(?:www\.)?youtube\.com\/(?:watch(?:\.php)?\?.*v=)|v\/)([a-zA-Z0-9\-_])/;
 
 export function isLinkValid(url) {
   if (youtubeRegex.test(url)) {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "start": "babel-node index.js",
     "test:server": "mocha --compilers js:babel/register --require ./server/test/test_helper.js --recursive 'server/test/**/*.@(js|jsx)'",
     "test:client": "mocha --compilers js:babel-core/register --require ./app/test/test_helper.js --recursive 'app/test/**/*.@(js|jsx)'",
-    "test": "npm run test:client",
+    "test": "npm run test:common && npm run test:client",
     "test:server-watch": "npm run test:server -- --watch",
     "test:client-watch": "npm run test:client -- --watch",
+    "test:common": "mocha --compilers js:babel-core/register --recursive './test/**/*.@(js|jsx)'",
     "test:watch": "npm run test -- --watch",
     "lint": "eslint .",
     "build": "rimraf dist && NODE_ENV=production webpack --config ./webpack.production.config.js --progress --profile --colors"

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,7 +11,6 @@ describe('utils', () => {
         expect(isLinkValid(url)).to.be.ok;
       });
 
-      /* FAILING TEST */
       it('handles /v/id style links', () => {
         const url = 'https://www.youtube.com/v/0zM3nApSvMg?fs=1&amp;hl=en_US&amp;rel=0';
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -23,6 +23,12 @@ describe('utils', () => {
 
         expect(isLinkValid(url)).to.be.ok;
       });
+
+      it('should not handle google links', () => {
+        const url = 'https://google.com';
+
+        expect(isLinkValid(url)).to.not.be.ok;
+      });
     });
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -8,14 +8,20 @@ describe('utils', () => {
     describe('youtube links', () => {
       it('handles multiple query strings', () => {
         const url = 'http://www.youtube.com/watch?v=abc123&feature=index';
-        expect(isLinkValid(url)).to.be.true;
+        expect(isLinkValid(url)).to.be.ok;
       });
 
       /* FAILING TEST */
       it('handles /v/id style links', () => {
         const url = 'https://www.youtube.com/v/0zM3nApSvMg?fs=1&amp;hl=en_US&amp;rel=0';
 
-        expect(isLinkValid(url)).to.be.true;
+        expect(isLinkValid(url)).to.be.ok;
+      });
+
+      it('handles youtu.be/id links', () => {
+        const url = 'http://youtu.be/0zM3nApSvMg';
+
+        expect(isLinkValid(url)).to.be.ok;
       });
     });
   });

--- a/test/utils.js
+++ b/test/utils.js
@@ -28,6 +28,12 @@ describe('utils', () => {
 
         expect(isLinkValid(url)).to.not.be.ok;
       });
+
+      it('handles regular single query string links', () => {
+        const url = 'https://www.youtube.com/watch?v=mbyG85GZ0PI';
+
+        expect(isLinkValid(url)).to.be.ok;
+      });
     });
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,10 +4,12 @@ import { expect } from 'chai';
 import { isLinkValid } from '../common/utils/functions';
 
 describe('utils', () => {
-  describe('youtube links', () => {
-    it('validifies urls with multiple query strings', () => {
-      const url = 'http://www.youtube.com/watch?v=abc123&feature=index';
-      expect(isLinkValid(url)).to.be.true;
+  describe('valid urls', () => {
+    describe('youtube links', () => {
+      it('multiple query strings', () => {
+        const url = 'http://www.youtube.com/watch?v=abc123&feature=index';
+        expect(isLinkValid(url)).to.be.true;
+      });
     });
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,6 +34,12 @@ describe('utils', () => {
 
         expect(isLinkValid(url)).to.be.ok;
       });
+
+      it('handles embed links', () => {
+        const url = 'http://www.youtube.com/embed/mbyG85GZ0PI?rel=0';
+
+        expect(isLinkValid(url)).to.be.ok;
+      });
     });
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,14 @@
+/* eslint "no-unused-expressions": 0 */
+
+import { expect } from 'chai';
+import { isLinkValid } from '../common/utils/functions';
+
+describe('utils', () => {
+  describe('youtube links', () => {
+    it('validifies urls with multiple query strings', () => {
+      const url = 'http://www.youtube.com/watch?v=abc123&feature=index';
+      expect(isLinkValid(url)).to.be.true;
+    });
+  });
+
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,8 +6,15 @@ import { isLinkValid } from '../common/utils/functions';
 describe('utils', () => {
   describe('valid urls', () => {
     describe('youtube links', () => {
-      it('multiple query strings', () => {
+      it('handles multiple query strings', () => {
         const url = 'http://www.youtube.com/watch?v=abc123&feature=index';
+        expect(isLinkValid(url)).to.be.true;
+      });
+
+      /* FAILING TEST */
+      it('handles /v/id style links', () => {
+        const url = 'https://www.youtube.com/v/0zM3nApSvMg?fs=1&amp;hl=en_US&amp;rel=0';
+
         expect(isLinkValid(url)).to.be.true;
       });
     });


### PR DESCRIPTION
Also adds support for /v/id style links and /embed/id style links since I wrote tests that broke the regex.

Add tests for `common/utils` youtube link checker. These now run with the travis builds as well.
I had to change the youtube regex to fix some links that it was not checking.
The tests are tests for [truthy](http://chaijs.com/api/bdd/#-ok) values, since we could probably combine `isLinkValid` and `getVidID` into one function that returns the id if the link was valid.
