### PR TITLE
getVidFromUrl tests

### DIFF
--- a/common/utils/functions.js
+++ b/common/utils/functions.js
@@ -1,5 +1,5 @@
 const youtubeRegex =
-        /(?:https?:\/\/)?(?:youtu\.be\/|(?:www\.)?youtube\.com\/(?:watch(?:\.php)?\?.*v=)|v\/|embed\/)([a-zA-Z0-9\-_])/;
+        /(?:https?:\/\/)?(?:youtu\.be\/|(?:www\.)?youtube\.com\/(?:watch(?:\.php)?\?.*v=)|v\/|embed\/)([a-zA-Z0-9\-_]+).*/;
 
 export function isLinkValid(url) {
   if (youtubeRegex.test(url)) {
@@ -9,14 +9,12 @@ export function isLinkValid(url) {
 }
 
 export function getVidFromUrl(url) {
-  let vid = null;
-  if (!(url.indexOf('v=') === -1)) {
-    vid = url.split('v=');
-    vid = vid[1].split('&');
-    return vid[0];
-  } else if (url.indexOf('youtu.be') !== -1) {
-    vid = url.split('be/');
-    return vid[1];
+  const match = youtubeRegex.exec(url);
+
+  if (match && match.length >= 1) {
+    // Return the first group, which is the youtube id
+    return match[1];
   }
+
   return 'error';
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -25,6 +25,10 @@ describe('utils', () => {
       it('gets id from youtu.be/id links', () => {
         expect(getVidFromUrl(shortYoutubeUrl)).to.equal(expectedId);
       });
+
+      it('gets id from regular single query string links', () => {
+        expect(getVidFromUrl(regularUrl)).to.equal(expectedId);
+      });
     });
 
     describe('valid urls', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,18 +1,25 @@
 /* eslint "no-unused-expressions": 0 */
 
 import { expect } from 'chai';
-import { isLinkValid } from '../common/utils/functions';
+import { isLinkValid, getVidFromUrl } from '../common/utils/functions';
 
 describe('utils', () => {
-  const multipleQueryStringUrl = 'http://www.youtube.com/watch?v=abc123&feature=index';
-  const vIdUrl = 'https://www.youtube.com/v/0zM3nApSvMg?fs=1&amp;hl=en_US&amp;rel=0';
-  const shortYoutubeUrl = 'http://youtu.be/0zM3nApSvMg';
+  const multipleQueryStringUrl = 'http://www.youtube.com/watch?v=mbyG85GZ0PI&feature=index';
+  const vIdUrl = 'https://www.youtube.com/v/mbyG85GZ0PI?fs=1&amp;hl=en_US&amp;rel=0';
+  const shortYoutubeUrl = 'http://youtu.be/mbyG85GZ0PI';
   const googleUrl = 'https://google.com';
   const regularUrl = 'https://www.youtube.com/watch?v=mbyG85GZ0PI';
   const embedUrl = 'http://www.youtube.com/embed/mbyG85GZ0PI?rel=0';
+  const expectedId = 'mbyG85GZ0PI';
 
-  describe('valid urls', () => {
-    describe('youtube links', () => {
+  describe('youtube links', () => {
+    describe('getVidFromUrl', () => {
+      it('gets id with multiple query strings', () => {
+        expect(getVidFromUrl(multipleQueryStringUrl)).to.equal(expectedId);
+      });
+    });
+
+    describe('valid urls', () => {
       it('handles multiple query strings', () => {
         expect(isLinkValid(multipleQueryStringUrl)).to.be.ok;
       });

--- a/test/utils.js
+++ b/test/utils.js
@@ -29,6 +29,10 @@ describe('utils', () => {
       it('gets id from regular single query string links', () => {
         expect(getVidFromUrl(regularUrl)).to.equal(expectedId);
       });
+
+      it('gets id from embed links', () => {
+        expect(getVidFromUrl(embedUrl)).to.equal(expectedId);
+      });
     });
 
     describe('valid urls', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,6 +17,10 @@ describe('utils', () => {
       it('gets id with multiple query strings', () => {
         expect(getVidFromUrl(multipleQueryStringUrl)).to.equal(expectedId);
       });
+
+      it('gets id from /v/id style links', () => {
+        expect(getVidFromUrl(vIdUrl)).to.equal(expectedId);
+      });
     });
 
     describe('valid urls', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -21,6 +21,10 @@ describe('utils', () => {
       it('gets id from /v/id style links', () => {
         expect(getVidFromUrl(vIdUrl)).to.equal(expectedId);
       });
+
+      it('gets id from youtu.be/id links', () => {
+        expect(getVidFromUrl(shortYoutubeUrl)).to.equal(expectedId);
+      });
     });
 
     describe('valid urls', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,41 +4,37 @@ import { expect } from 'chai';
 import { isLinkValid } from '../common/utils/functions';
 
 describe('utils', () => {
+  const multipleQueryStringUrl = 'http://www.youtube.com/watch?v=abc123&feature=index';
+  const vIdUrl = 'https://www.youtube.com/v/0zM3nApSvMg?fs=1&amp;hl=en_US&amp;rel=0';
+  const shortYoutubeUrl = 'http://youtu.be/0zM3nApSvMg';
+  const googleUrl = 'https://google.com';
+  const regularUrl = 'https://www.youtube.com/watch?v=mbyG85GZ0PI';
+  const embedUrl = 'http://www.youtube.com/embed/mbyG85GZ0PI?rel=0';
+
   describe('valid urls', () => {
     describe('youtube links', () => {
       it('handles multiple query strings', () => {
-        const url = 'http://www.youtube.com/watch?v=abc123&feature=index';
-        expect(isLinkValid(url)).to.be.ok;
+        expect(isLinkValid(multipleQueryStringUrl)).to.be.ok;
       });
 
       it('handles /v/id style links', () => {
-        const url = 'https://www.youtube.com/v/0zM3nApSvMg?fs=1&amp;hl=en_US&amp;rel=0';
-
-        expect(isLinkValid(url)).to.be.ok;
+        expect(isLinkValid(vIdUrl)).to.be.ok;
       });
 
       it('handles youtu.be/id links', () => {
-        const url = 'http://youtu.be/0zM3nApSvMg';
-
-        expect(isLinkValid(url)).to.be.ok;
+        expect(isLinkValid(shortYoutubeUrl)).to.be.ok;
       });
 
       it('should not handle google links', () => {
-        const url = 'https://google.com';
-
-        expect(isLinkValid(url)).to.not.be.ok;
+        expect(isLinkValid(googleUrl)).to.not.be.ok;
       });
 
       it('handles regular single query string links', () => {
-        const url = 'https://www.youtube.com/watch?v=mbyG85GZ0PI';
-
-        expect(isLinkValid(url)).to.be.ok;
+        expect(isLinkValid(regularUrl)).to.be.ok;
       });
 
       it('handles embed links', () => {
-        const url = 'http://www.youtube.com/embed/mbyG85GZ0PI?rel=0';
-
-        expect(isLinkValid(url)).to.be.ok;
+        expect(isLinkValid(embedUrl)).to.be.ok;
       });
     });
   });


### PR DESCRIPTION
Refactor `getVidFromUrl` to get all id's in the failing tests.

Tests for 5 different url types. `getVidFromUrl` still returns the string `'error'` for an error, which should probably change to something else at some point. I just left it as is, in case some front end code is looking for the string `'error'`.
