### PR TITLE
Remove GA from index template

### DIFF
--- a/app/index.template.html
+++ b/app/index.template.html
@@ -9,16 +9,6 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.6/semantic.min.js"></script>
         <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.6/semantic.min.css">
-        <script>
-         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                                  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-         ga('create', 'UA-70628505-1', 'auto');
-         ga('send', 'pageview');
-
-        </script>
     </head>
     <body style="background-color: #1A1A1A;">
         <div id="root"></div>


### PR DESCRIPTION
This is already handled through `react-ga` so we don't need a second import.
