### PR TITLE
Fix id selector bug in create/join room

### DIFF
--- a/server/landing/index.html
+++ b/server/landing/index.html
@@ -136,10 +136,7 @@
          return;
        }
 
-       var url = window.location.href;
-       url += (url[url.length-1] === "/") ? rname : "/" + rname;
-       window.location.href = url;
-
+       window.location.href = rname;
      }
 
      $(document).ready(function(){


### PR DESCRIPTION
If we are on page: partyq.io/#page-top, and then we try to make a room abc
the old version would incorrectly try to go to partyq.io/#page-top/abc.

Now it goes to partyq.io/abc
